### PR TITLE
Fix credential body parsing

### DIFF
--- a/node-red-contrib-bluemix-hdfs/package.json
+++ b/node-red-contrib-bluemix-hdfs/package.json
@@ -6,7 +6,7 @@
   },
   "name": "node-red-contrib-bluemix-hdfs",
   "description": "Big Data node on IBM Bluemix. \n\nThis Node-RED node runs only in the IBM Bluemix environment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "keywords": [
     "node-red"
   ],

--- a/node-red-contrib-ibmpush/ibmpush/88-ibmpush.js
+++ b/node-red-contrib-ibmpush/ibmpush/88-ibmpush.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 IBM Corp.
+ * Copyright 2014, 2015 IBM Corp.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,8 +18,6 @@ var RED = require(process.env.NODE_RED_HOME + "/red/red");
 
 var ibmbluemix = require('ibmbluemix');
 var ibmpush = require('ibmpush');
-var querystring = require("querystring");
-
 
 var isVCapEnv = process.env.VCAP_APPLICATION ? true:false;
 
@@ -51,25 +49,17 @@ RED.httpAdmin.delete('/ibmpush/:id', function(req,res) {
 });
 
 RED.httpAdmin.post('/ibmpush/:id', function(req,res) {
-    var body = "";
+    var newCreds = req.body;
+    var credentials = RED.nodes.getCredentials(req.params.id) || {};
 
-    req.on('data', function(chunk) {
-        body += chunk;
-    });
+    if (newCreds.password == "") {
+        delete credentials.password;
+    } else {
+        credentials.password = newCreds.password || credentials.password;
+    }
 
-    req.on('end', function() {
-        var newCreds = querystring.parse(body);
-        var credentials = RED.nodes.getCredentials(req.params.id) || {};
-
-        if (newCreds.password == "") {
-            delete credentials.password;
-        } else {
-            credentials.password = newCreds.password || credentials.password;
-        }
-
-        RED.nodes.addCredentials(req.params.id, credentials);
-        res.send(200);
-    });
+    RED.nodes.addCredentials(req.params.id, credentials);
+    res.send(200);
 });
 
 

--- a/node-red-contrib-ibmpush/package.json
+++ b/node-red-contrib-ibmpush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ibmpush",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "Apache",
   "repository" : {
 	"type":"git",

--- a/node-red-contrib-scx-ibmiotapp/application/97-iotnewapp-cf.js
+++ b/node-red-contrib-scx-ibmiotapp/application/97-iotnewapp-cf.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 IBM Corp.
+ * Copyright 2014, 2015 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,8 +134,6 @@ function IotAppNode(n) {
 
 RED.nodes.registerType("ibmiot",IotAppNode);
 
-var querystring = require('querystring');
-
 RED.httpAdmin.get('/ibmiot/:id',function(req,res) {
 	var newCredentials = RED.nodes.getCredentials(req.params.id);
 	if (newCredentials) {
@@ -154,26 +152,20 @@ RED.httpAdmin.delete('/ibmiot/:id',function(req,res) {
 
 RED.httpAdmin.post('/ibmiot/:id',function(req,res) {
 //	console.log("IN POST ");
-	var body = "";
-	req.on('data', function(chunk) {
-		body += chunk;
-	});
-	req.on('end', function(){
-		var newCreds = querystring.parse(body);
-		var newCredentials = RED.nodes.getCredentials(req.params.id)||{};
-		if (newCreds.user == null || newCreds.user == "") {
-			delete newCredentials.user;
-		} else {
-			newCredentials.user = newCreds.user;
-		}
-		if (newCreds.password == "") {
-			delete newCredentials.password;
-		} else {
-			newCredentials.password = newCreds.password || newCredentials.password;
-		}
-		RED.nodes.addCredentials(req.params.id, newCredentials);
-		res.send(200);
-	});
+    var newCreds = req.body;
+    var newCredentials = RED.nodes.getCredentials(req.params.id)||{};
+    if (newCreds.user == null || newCreds.user == "") {
+        delete newCredentials.user;
+    } else {
+        newCredentials.user = newCreds.user;
+    }
+    if (newCreds.password == "") {
+        delete newCredentials.password;
+    } else {
+        newCredentials.password = newCreds.password || newCredentials.password;
+    }
+    RED.nodes.addCredentials(req.params.id, newCredentials);
+    res.send(200);
 });
 
 

--- a/node-red-contrib-scx-ibmiotapp/package.json
+++ b/node-red-contrib-scx-ibmiotapp/package.json
@@ -10,7 +10,7 @@
     "cfenv": "1.0.0",
     "iotclient": "0.1.3"
   },
-  "version": "0.0.8",
+  "version": "0.0.9",
   "keywords": [
     "node-red",
     "bluemix",


### PR DESCRIPTION
JSON Parsing middleware is now installed by default in node-red. This means it isn't necessary to read the entire body before trying to parse.

Ideally, these nodes would be updated to use the built-in [credential system](http://nodered.org/docs/creating-nodes/credentials.html) that removes the need to create all of these http routes.