### PR TITLE
An untested fix to the broken HDFS node

### DIFF
--- a/node-red-contrib-bluemix-hdfs/application/47-ibmhdfs-cf.js
+++ b/node-red-contrib-bluemix-hdfs/application/47-ibmhdfs-cf.js
@@ -116,9 +116,16 @@ function HDFSRequestInNode(n) {
 				} else {
 					msg.payload = "";
 				}
+				var begun = false;
 				res.on('data',function(chunk) {
 					node.status({fill:"green",shape:"dot",text:"connected"});
-					msg.payload = chunk;
+					if( begun )
+						msg.payload += chunk;
+					else {
+						msg.payload = chunk;
+						begun = true;
+					}
+
 					payload = msg.payload;
 
 					node.log("Payload in DATA = " + msg.payload);


### PR DESCRIPTION
The issue: it only returns the last chunk, if the HTTP response from HDFS is chunked.
This is a critical issue for the application I'm currently developing, but I'll likely have to hack around it before the deadline to the BigDataForSocialGood challenge.

Please feel free to contact me:
amcgail@perscio.com