### PR TITLE
Remove Watson IoT node hard dependency on NR 0.13 

### DIFF
--- a/node-red-contrib-ibm-watson-iot/README.md
+++ b/node-red-contrib-ibm-watson-iot/README.md
@@ -4,8 +4,6 @@ node-red-contrib-ibm-watson-iot
 A pair of Node-RED nodes for connecting to the IBM Watson Internet of Things Platform
 as a Device or Gateway.
 
-This node requires Node-RED version 0.13 or later.
-
 ## Install
 
 Run the following command in the user directory of your Node-RED install. This is

--- a/node-red-contrib-ibm-watson-iot/application/wiotp.html
+++ b/node-red-contrib-ibm-watson-iot/application/wiotp.html
@@ -39,6 +39,10 @@
 
 <script type="text/javascript">
 (function() {
+
+    var hasTypedInputs = (typeof jQuery.nodered !== "undefined") && (typeof jQuery.nodered.typedInput !== "undefined");
+
+
     RED.nodes.registerType('wiotp-credentials',{
         category: 'config',
         defaults: {
@@ -84,20 +88,42 @@
         },
         paletteLabel: "Watson IoT",
         oneditprepare: function() {
-            var command = $("#node-input-command").typedInput({
-                default: 'all',
-                types:[{value:"str",label:"specify command",icon:"red/images/typedInput/az.png"},{value:"all",label:"all commands",hasValue:false}]
-            });
+            if (hasTypedInputs) {
+                var command = $("#node-input-command").typedInput({
+                    default: 'all',
+                    types:[{value:"str",label:"specify command",icon:"red/images/typedInput/az.png"},{value:"all",label:"all commands",hasValue:false}]
+                });
 
-            if (this.command === '' || this.command === '+') {
-                command.typedInput('value','');
-                command.typedInput('type','all');
+                if (this.command === '' || this.command === '+') {
+                    command.typedInput('value','');
+                    command.typedInput('type','all');
+                } else {
+                    command.typedInput('value',this.command);
+                    command.typedInput('type','str');
+                }
             } else {
-                command.typedInput('value',this.command);
-                command.typedInput('type','str');
+                $('#node-input-command').width(250);
+                $('<label style="width:auto;" for="node-input-command-all"><input style="width: auto; margin-right: 5px; vertical-align: top;" type="radio" id="node-input-command-all" name="node-input-command" value="all"> all </label>').insertBefore("#node-input-command");
+                $('<label style="width:auto; margin-left: 10px;" for="node-input-command-input"><input style="width: auto; margin-right: 5px; vertical-align: top;" type="radio" id="node-input-command-input" name="node-input-command" value="input"> </label>').insertBefore("#node-input-command");
+
+                function updateCommandOptions() {
+                    var commandType = $("#node-form-row-command input[type='radio']:checked").val();
+                    if (commandType === 'all') {
+                        $('#node-input-command').val("");
+                    }
+                }
+                $("#node-form-row-command input[type='radio']").change(updateCommandOptions);
+                if (this.command === '' || this.command === '+') {
+                    $("#node-form-row-command input[type='radio'][value='all']").prop('checked',true).change();
+                } else {
+                    $("#node-form-row-command input[type='radio'][value='input']").prop('checked',true).change();
+                }
+                $('#node-input-command').on('click',function() {
+                    $("#node-form-row-command input[type='radio'][value='input']").prop('checked',true);
+                })
             }
 
-            $("#node-form-row-commandType input[type='radio'][value='"+(this.commandType||'g')+"']").attr('checked',true).change();
+            $("#node-form-row-commandType input[type='radio'][value='"+(this.commandType||'g')+"']").prop('checked',true).change();
 
 
             function updateOptions() {
@@ -122,8 +148,15 @@
             updateOptions();
         },
         oneditsave: function() {
-            if ($("#node-input-command").typedInput('type') === 'all') {
-                $("#node-input-command").typedInput('value','+');
+            if (hasTypedInputs) {
+                if ($("#node-input-command").typedInput('type') === 'all') {
+                    $("#node-input-command").typedInput('value','+');
+                }
+            } else {
+                var commandType = $("#node-form-row-command input[type='radio']:checked").val();
+                if (commandType === 'all') {
+                    $("#node-input-command").val('+');
+                }
             }
             this.commandType = $("#node-form-row-commandType input[type='radio']:checked").val();
             if (this.commandType === 'g') {
@@ -201,16 +234,38 @@
             $("#node-input-authType").change(updateOptions);
             updateOptions();
 
-            var format = $("#node-input-format").typedInput({
-                default: 'json',
-                types:[{value:"json",label:"json",hasValue:false},{value:"str",label:"other",icon:"red/images/typedInput/az.png"}]
-            });
-            if (this.format === 'json') {
-                format.typedInput('value','');
-                format.typedInput('type','json');
+            if (hasTypedInputs) {
+                var format = $("#node-input-format").typedInput({
+                    default: 'json',
+                    types:[{value:"json",label:"json",hasValue:false},{value:"str",label:"other",icon:"red/images/typedInput/az.png"}]
+                });
+                if (this.format === 'json') {
+                    format.typedInput('value','');
+                    format.typedInput('type','json');
+                } else {
+                    format.typedInput('value',this.format);
+                    format.typedInput('type','str');
+                }
             } else {
-                format.typedInput('value',this.format);
-                format.typedInput('type','str');
+                $('#node-input-format').width(230);
+                $('<label style="width:auto;" for="node-input-format-json"><input style="width: auto; margin-right: 5px; vertical-align: top;" type="radio" id="node-input-format-json" name="node-input-format" value="json"> json </label>').insertBefore("#node-input-format");
+                $('<label style="width:auto; margin-left: 10px;" for="node-input-format-input"><input style="width: auto; margin-right: 5px; vertical-align: top;" type="radio" id="node-input-format-input" name="node-input-format" value="input"> </label>').insertBefore("#node-input-format");
+
+                function updateFormatOptions() {
+                    var formatType = $("#node-form-row-format input[type='radio']:checked").val();
+                    if (formatType === 'json') {
+                        $('#node-input-format').val("");
+                    }
+                }
+                $("#node-form-row-format input[type='radio']").change(updateFormatOptions);
+                if (this.format === 'json' || this.format === '') {
+                    $("#node-form-row-format input[type='radio'][value='json']").prop('checked',true).change();
+                } else {
+                    $("#node-form-row-format input[type='radio'][value='input']").prop('checked',true).change();
+                }
+                $('#node-input-format').on('click',function() {
+                    $("#node-form-row-format input[type='radio'][value='input']").prop('checked',true);
+                })
             }
             $("#node-input-qsDeviceId").change(function() {
                 if ($(this).val() === '') {
@@ -235,8 +290,15 @@
             } else {
                 $("#node-input-qsDeviceId").val('');
             }
-            if ($("#node-input-format").typedInput('type') === 'json') {
-                $("#node-input-format").typedInput('value','json');
+            if (hasTypedInputs) {
+                if ($("#node-input-format").typedInput('type') === 'json') {
+                    $("#node-input-format").typedInput('value','json');
+                }
+            } else {
+                var formatType = $("#node-form-row-format input[type='radio']:checked").val();
+                if (formatType === 'json') {
+                    $("#node-input-format").val('json');
+                }
             }
 
         }

--- a/node-red-contrib-ibm-watson-iot/application/wiotp.html
+++ b/node-red-contrib-ibm-watson-iot/application/wiotp.html
@@ -35,10 +35,6 @@
         <label for="node-config-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-config-input-name" placeholder="Name">
     </div>
-    <div class="form-tips hidden" id="node-config-tip-bluemix">
-        <b>Note:</b> if used with a bound Bluemix Service, the Organization field
-        can be left blank.
-    </div>
 </script>
 
 <script type="text/javascript">
@@ -282,6 +278,11 @@
         <label for="node-input-command">Command</label>
         <input type="text" id="node-input-command" placeholder="e.g. blink" style="width: 300px;">
     </div>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
+    </div>
 </script>
 
 <script type="text/x-red" data-template-name="wiotp out">
@@ -327,6 +328,11 @@
     <div class="form-row" id="node-form-row-format">
         <label for="node-input-format">Format</label>
         <input type="text" id="node-input-format" placeholder="e.g. text, xml" style="width: 300px;">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
     </div>
 </script>
 

--- a/node-red-contrib-ibm-watson-iot/package.json
+++ b/node-red-contrib-ibm-watson-iot/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "ibmiotf": "0.2.*"
     },
-    "version": "0.2.1",
+    "version": "0.2.3",
     "keywords": [
         "node-red",
         "bluemix",


### PR DESCRIPTION
The node uses the new typedInput widget only available in Node-RED 0.13 and later. This change allows the node to fall back to a simple checkbox/input ui if typedInput is not available (ie running on an older version of NR).

It also adds missing name fields in the ui